### PR TITLE
Update bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -15,6 +15,7 @@
   ],
   "dependencies": {
     "angular": "~1.3.12",
-    "tink-core": "latest"
+    "tink-core": "latest",
+    "awelzijn-notification-service": "latest"
   }
 }


### PR DESCRIPTION
awelzijn-notification-service should be defined as a dependency, because this component can't work without it.
